### PR TITLE
Add references and extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"charliermarsh.ruff",
+		"biomejs.biome",
+		"ms-azuretools.vscode-docker"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,12 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
-		"charliermarsh.ruff",
-		"biomejs.biome",
-		"ms-azuretools.vscode-docker"
-	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": []
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "charliermarsh.ruff",
+    "biomejs.biome",
+    "ms-azuretools.vscode-docker"
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
 }

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,19 @@
+### GitHub Actions:
+- https://docs.github.com/en/actions/get-started/understand-github-actions
+- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
+- https://docs.github.com/en/actions/get-started/continuous-integration
+- https://docs.github.com/en/actions/reference/workflows-and-actions/contexts
+
+### ADR (Architecture Decision Record):
+- https://github.com/joelparkerhenderson/architecture-decision-record?tab=readme-ov-file
+- https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-michael-nygard
+
+### Pre-Commit:
+- https://pre-commit.com/
+- Find more hooks here: https://pre-commit.com/hooks.html
+- Used hooks:
+    - https://github.com/pre-commit/pre-commit-hooks
+    - https://github.com/astral-sh/ruff-pre-commit?tab=readme-ov-file#ruff-pre-commit
+    - https://github.com/biomejs/pre-commit?tab=readme-ov-file#using-biome-with-a-local-pre-commit-hook
+
+### Docker


### PR DESCRIPTION
This pull request introduces workspace setup improvements and documentation enhancements to support development best practices and easier onboarding.

Workspace setup:

* Added a `.vscode/extensions.json` file recommending the `ruff`, `biome`, and `vscode-docker` extensions for VS Code users in this workspace.

Documentation enhancements:

* Added a new section to `docs/references.md` with helpful links for GitHub Actions, Architecture Decision Records (ADR), Pre-Commit, and Docker, including links to relevant documentation and commonly used hooks.