### PR TITLE
Implement mypy for backend type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Run Linter (Ruff)
         run: uv run ruff check .
 
+      - name: Type Check (mypy)
+        run: uv run mypy .
+
   docker-checks:
     name: Docker Compose Build
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,22 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff-check
-        args: [ --fix ]
+        args: [--fix]
         files: ^backend/
       # Run the formatter.
       - id: ruff-format
         files: ^backend/
+
+  # Static Type Checking
+  - repo: local
+    hooks:
+      - id: local-mypy-check
+        name: mypy
+        entry: bash -c "cd backend && uv run mypy ."
+        language: system
+        types: [python]
+        # Must be false to catch cross-file breakages by checking the whole project
+        pass_filenames: false
 
   # https://github.com/biomejs/pre-commit?tab=readme-ov-file#using-biome-with-a-local-pre-commit-hook
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,12 @@ repos:
     hooks:
       - id: local-mypy-check
         name: mypy
-        entry: bash -c "cd backend && uv run mypy ."
+        entry: uv run --directory backend mypy .
         language: system
         types: [python]
         # Must be false to catch cross-file breakages by checking the whole project
         pass_filenames: false
+        files: ^backend/
 
   # https://github.com/biomejs/pre-commit?tab=readme-ov-file#using-biome-with-a-local-pre-commit-hook
   - repo: local

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,8 +15,9 @@ Backend service for DevTrackr - a developer activity tracking and logging system
 
 ## Development Tools
 
-- **Code Formatting**: Black (line length: 88)
+- **Code Formatting**: Ruff (line length: 88)
 - **Linting**: Ruff (with Pycodestyle, Pyflakes, Import sorting, and modernization rules)
+- **Type Checking**: mypy (strict mode), configured in pyproject.toml
 - **Testing**: pytest
 
 ## Architecture

--- a/backend/app/api/v1/routes.py
+++ b/backend/app/api/v1/routes.py
@@ -4,5 +4,5 @@ router = APIRouter()
 
 
 @router.get("/ping", status_code=status.HTTP_200_OK)
-def ping():
+def ping() -> dict[str, str]:
     return {"status": "ok"}

--- a/backend/app/backend_prestart.py
+++ b/backend/app/backend_prestart.py
@@ -19,7 +19,7 @@ wait_seconds = 1
     before=before_log(logger, logging.INFO),
     after=after_log(logger, logging.WARN),
 )
-async def init():
+async def init() -> None:
     try:
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
@@ -28,7 +28,7 @@ async def init():
         raise e
 
 
-async def main():
+async def main() -> None:
     logger.info("Initializing service")
     await init()
     logger.info("Service finished initializing")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,8 +42,8 @@ class Settings(BaseSettings):
             self.EMAILS_FROM_NAME = self.PROJECT_NAME
         return self
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
-    @computed_field
     def emails_enabled(self) -> bool:
         return bool(self.SMTP_HOST and self.EMAILS_FROM_EMAIL)
 
@@ -54,8 +54,8 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str = ""
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
-    @computed_field
     def DATABASE_URL(self) -> PostgresDsn:
         return PostgresDsn.build(
             scheme="postgresql+psycopg",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,6 @@
 from typing import Literal, Self
 
 from pydantic import EmailStr, PostgresDsn, SecretStr, computed_field, model_validator
-from pydantic_core import MultiHostUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -43,8 +42,8 @@ class Settings(BaseSettings):
             self.EMAILS_FROM_NAME = self.PROJECT_NAME
         return self
 
-    @computed_field
     @property
+    @computed_field
     def emails_enabled(self) -> bool:
         return bool(self.SMTP_HOST and self.EMAILS_FROM_EMAIL)
 
@@ -55,10 +54,10 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str = ""
 
-    @computed_field
     @property
+    @computed_field
     def DATABASE_URL(self) -> PostgresDsn:
-        return MultiHostUrl.build(
+        return PostgresDsn.build(
             scheme="postgresql+psycopg",
             username=self.POSTGRES_USER,
             password=self.POSTGRES_PASSWORD,

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,3 +1,5 @@
+from collections.abc import AsyncGenerator
+
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -6,7 +8,7 @@ from app.core.config import settings
 
 engine = create_async_engine(
     str(settings.DATABASE_URL),
-    echo=settings.ENVIRONMENT == "local",  # Log SQL queries in local environment
+    echo=settings.ENVIRONMENT == "development",  # Log SQL queries in dev environment
 )
 
 # Use AsyncSession with sessionmaker
@@ -16,10 +18,10 @@ AsyncSessionLocal = sessionmaker(
     class_=AsyncSession,
     expire_on_commit=False,
     autoflush=False,
-)
+)  # type: ignore
 
 
 # Dependency for FastAPI Routes
-async def get_db():
+async def get_db() -> AsyncGenerator[AsyncSession]:
     async with AsyncSessionLocal() as session:
         yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,5 +11,5 @@ app.include_router(api_router, prefix="/api/v1")
 
 
 @app.get("/")
-def root():
+def root() -> dict[str, str]:
     return {"message": "Welcome to DevTrackr!"}

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -9,23 +9,17 @@ class BaseModel(SQLModel):
     is_active: bool = Field(default=True)
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column_kwargs={
-            "type_": DateTime(timezone=True),
-            "nullable": False,
-        },
+        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
+        nullable=False,
     )
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column_kwargs={
-            "type_": DateTime(timezone=True),
-            "nullable": False,
-            "onupdate": lambda: datetime.now(UTC),  # Auto-update on save
-        },
+        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
+        nullable=False,
+        sa_column_kwargs={"onupdate": lambda: datetime.now(UTC)},
     )
     deleted_at: datetime | None = Field(
         default=None,
-        sa_column_kwargs={
-            "type_": DateTime(timezone=True),
-            "nullable": True,
-        },
+        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
+        nullable=True,
     )

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -9,15 +9,23 @@ class BaseModel(SQLModel):
     is_active: bool = Field(default=True)
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_type=DateTime(timezone=True),
-        nullable=False,
+        sa_column_kwargs={
+            "type_": DateTime(timezone=True),
+            "nullable": False,
+        },
     )
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_type=DateTime(timezone=True),
-        nullable=False,
         sa_column_kwargs={
+            "type_": DateTime(timezone=True),
+            "nullable": False,
             "onupdate": lambda: datetime.now(UTC),  # Auto-update on save
         },
     )
-    deleted_at: datetime | None = Field(default=None, sa_type=DateTime(timezone=True))
+    deleted_at: datetime | None = Field(
+        default=None,
+        sa_column_kwargs={
+            "type_": DateTime(timezone=True),
+            "nullable": True,
+        },
+    )

--- a/backend/app/models/base_types.py
+++ b/backend/app/models/base_types.py
@@ -1,15 +1,17 @@
+from typing import Any
+
 from cryptography.fernet import Fernet
-from sqlalchemy import LargeBinary, TypeDecorator
+from sqlalchemy import Dialect, LargeBinary, TypeDecorator
 
 from app.core.config import settings
 
 
-class EncryptedString(TypeDecorator):
+class EncryptedString(TypeDecorator[str]):
     impl = LargeBinary
     cache_ok = True
 
     @property
-    def _fernet(self):
+    def _fernet(self) -> Fernet:
         try:
             return Fernet(settings.ENCRYPTION_KEY.get_secret_value().encode("utf-8"))
         except (TypeError, ValueError) as exc:
@@ -18,12 +20,12 @@ class EncryptedString(TypeDecorator):
                 "url-safe base64-encoded Fernet key."
             ) from exc
 
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(self, value: str | None, dialect: Dialect) -> bytes | None:
         if value is None:
             return None
-        return self._fernet.encrypt(value.encode("utf-8"))
+        return self._fernet.encrypt(str(value).encode("utf-8"))
 
-    def process_result_value(self, value, dialect):
+    def process_result_value(self, value: Any | None, dialect: Dialect) -> str | None:
         if value is None:
             return None
         return self._fernet.decrypt(value).decode("utf-8")

--- a/backend/app/models/commit.py
+++ b/backend/app/models/commit.py
@@ -10,10 +10,8 @@ class Commit(BaseModel, table=True):
     sha: str
     message: str
     committed_at: datetime = Field(
-        sa_column_kwargs={
-            "type_": DateTime(timezone=True),
-            "nullable": False,
-        },
+        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
+        nullable=False,
     )
     url: str | None = None
     repository_id: uuid.UUID = Field(

--- a/backend/app/models/commit.py
+++ b/backend/app/models/commit.py
@@ -9,7 +9,12 @@ from .base import BaseModel
 class Commit(BaseModel, table=True):
     sha: str
     message: str
-    committed_at: datetime = Field(sa_type=DateTime(timezone=True), nullable=False)
+    committed_at: datetime = Field(
+        sa_column_kwargs={
+            "type_": DateTime(timezone=True),
+            "nullable": False,
+        },
+    )
     url: str | None = None
     repository_id: uuid.UUID = Field(
         foreign_key="repository.id", nullable=False, ondelete="CASCADE"

--- a/backend/app/models/integration.py
+++ b/backend/app/models/integration.py
@@ -9,11 +9,15 @@ from .base_types import EncryptedString
 
 class Integration(BaseModel, table=True):
     provider: str = Field(index=True)
-    access_token: str = Field(sa_type=EncryptedString, nullable=False)
-    refresh_token: str | None = Field(
-        default=None, sa_type=EncryptedString, nullable=True
+    access_token: str = Field(
+        sa_column_kwargs={"type_": EncryptedString}, nullable=False
     )
-    token_expiry: datetime | None = Field(default=None, sa_type=DateTime(timezone=True))
+    refresh_token: str | None = Field(
+        default=None, sa_column_kwargs={"type_": EncryptedString}, nullable=True
+    )
+    token_expiry: datetime | None = Field(
+        default=None, sa_column_kwargs={"type_": DateTime(timezone=True)}
+    )
     user_id: uuid.UUID = Field(
         foreign_key="users.id", nullable=False, ondelete="CASCADE"
     )

--- a/backend/app/models/integration.py
+++ b/backend/app/models/integration.py
@@ -9,14 +9,15 @@ from .base_types import EncryptedString
 
 class Integration(BaseModel, table=True):
     provider: str = Field(index=True)
-    access_token: str = Field(
-        sa_column_kwargs={"type_": EncryptedString}, nullable=False
-    )
+    access_token: str = Field(sa_type=EncryptedString, nullable=False)  # type: ignore[call-overload]
     refresh_token: str | None = Field(
-        default=None, sa_column_kwargs={"type_": EncryptedString}, nullable=True
+        default=None,
+        sa_type=EncryptedString,
+        nullable=True,  # type: ignore[call-overload]
     )
     token_expiry: datetime | None = Field(
-        default=None, sa_column_kwargs={"type_": DateTime(timezone=True)}
+        default=None,
+        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
     )
     user_id: uuid.UUID = Field(
         foreign_key="users.id", nullable=False, ondelete="CASCADE"

--- a/backend/app/models/time_entry.py
+++ b/backend/app/models/time_entry.py
@@ -11,17 +11,13 @@ class TimeEntry(BaseModel, table=True):
 
     description: str | None = Field(default=None)
     start_time: datetime = Field(
-        sa_column_kwargs={
-            "type_": DateTime(timezone=True),
-            "nullable": False,
-        },
+        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
+        nullable=False,
     )
     end_time: datetime | None = Field(
         default=None,
-        sa_column_kwargs={
-            "type_": DateTime(timezone=True),
-            "nullable": True,
-        },
+        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
+        nullable=True,
     )
     duration_seconds: int | None = None
     project_id: uuid.UUID = Field(

--- a/backend/app/models/time_entry.py
+++ b/backend/app/models/time_entry.py
@@ -10,8 +10,19 @@ class TimeEntry(BaseModel, table=True):
     __tablename__ = "time_entry"
 
     description: str | None = Field(default=None)
-    start_time: datetime = Field(sa_type=DateTime(timezone=True), nullable=False)
-    end_time: datetime | None = Field(default=None, sa_type=DateTime(timezone=True))
+    start_time: datetime = Field(
+        sa_column_kwargs={
+            "type_": DateTime(timezone=True),
+            "nullable": False,
+        },
+    )
+    end_time: datetime | None = Field(
+        default=None,
+        sa_column_kwargs={
+            "type_": DateTime(timezone=True),
+            "nullable": True,
+        },
+    )
     duration_seconds: int | None = None
     project_id: uuid.UUID = Field(
         foreign_key="project.id", nullable=False, ondelete="CASCADE"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,9 +19,31 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "mypy>=1.19.1",
     "pytest>=8.4.2",
     "ruff>=0.14.1",
 ]
+
+
+[tool.mypy]
+plugins = ['pydantic.mypy']
+
+# Strict mode enables a battery of checks (highly recommended)
+strict = true
+
+# Ignore missing type hints from third-party libraries (like SQLModel/Alembic)
+ignore_missing_imports = true
+
+# Don't check the migration files or virtual environments
+exclude = ["alembic/", "\\.venv/"]
+
+[tool.pydantic-mypy]
+# Catch trying to pass arguments to a Pydantic model that don't exist
+init_forbid_extra = true
+# Ensure the arguments you pass to a Pydantic model match the correct types
+init_typed = true
+# Warn if you are doing weird things with dynamic aliases
+warn_required_dynamic_aliases = true
 
 
 [tool.ruff]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,8 +28,8 @@ dev = [
 [tool.mypy]
 plugins = ['pydantic.mypy']
 
-# Strict mode enables a battery of checks (highly recommended)
 strict = true
+disable_error_code = ["unused-ignore"]
 
 # Use explicit package bases and namespace packages to handle project structure
 # without requiring __init__.py files in every directory.
@@ -40,7 +40,7 @@ namespace_packages = true
 ignore_missing_imports = true
 
 # Don't check the migration files or virtual environments
-exclude = ["alembic/", "\\.venv/"]
+exclude = ["venv", ".venv", "alembic"]
 
 [tool.pydantic-mypy]
 # Catch trying to pass arguments to a Pydantic model that don't exist
@@ -58,11 +58,26 @@ extend-exclude = ["migrations"]
 
 [tool.ruff.lint]
 # Enable Ruff rules
-select = ["E", "F", "I", "UP"]
+# select = ["E", "F", "I", "UP"]
 #   E = Pycodestyle errors
 #   F = Pyflakes
 #   I = Import sorting
 #   UP = Modernization rules (use modern Python syntax)
+
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "B",  # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+    "I",   # Import sorting
+    "ARG001", # unused arguments in functions
+]
+
+ignore = [
+    "B008",  # do not perform function calls in argument defaults
+]
 
 [tool.ruff.format]
 # Ensure Ruff respects Black formatting style

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,11 @@ plugins = ['pydantic.mypy']
 # Strict mode enables a battery of checks (highly recommended)
 strict = true
 
+# Use explicit package bases and namespace packages to handle project structure
+# without requiring __init__.py files in every directory.
+explicit_package_bases = true
+namespace_packages = true
+
 # Ignore missing type hints from third-party libraries (like SQLModel/Alembic)
 ignore_missing_imports = true
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -185,6 +185,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -205,6 +206,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.14.1" },
 ]
@@ -409,6 +411,53 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -494,12 +543,57 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]

--- a/docs/references.md
+++ b/docs/references.md
@@ -20,4 +20,8 @@
 - https://cryptography.io/en/latest/fernet/
 - Used for transparently encrypting tokens.
 
+### Mypy
+- https://mypy.readthedocs.io/en/latest/extending_mypy.html
+- https://docs.pydantic.dev/latest/integrations/mypy/#__tabbed_2_2
+
 ### Docker


### PR DESCRIPTION
- Refactor SQLModel `Field` definitions to use `sa_column_kwargs` for
  SQLAlchemy-specific types to fix overload resolution issues.
- Reorder `@property` and `@computed_field` decorators in `Settings` for
  correct Pydantic/mypy compatibility.
- Update `DATABASE_URL` return type to `PostgresDsn` to fix `PostgresDsn` type mismatch.
- Add missing type annotations and fix `sessionmaker` typing in `session.py`.
- Correct environment string check from "local" to "development".
- Add mypy to ci and pre-commit