### PR TITLE
feat: update environment configuration for frontend port exposure

### DIFF
--- a/.claude/skills/process-review-comments/SKILL.md
+++ b/.claude/skills/process-review-comments/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: process-review-comments
+description: Use when receiving code review feedback: a single comment, a full batch from a PR review, or a pasted list of review items. Trigger on phrases like "review comments", "reviewer flagged", "AI said", "developer feedback", "fix this comment", or when the user pastes review items to process.
+---
+
+# Process Review Comments
+
+**REQUIRED BACKGROUND:** You MUST understand superpowers:receiving-code-review for behavioral norms: no performative agreement, when to push back, implementation order (blocking → simple → complex), and how to acknowledge correct feedback without gratitude. This skill adds the technical validation layer: reading code, checking project docs, verifying framework claims, and classifying each comment on its merits.
+
+## Overview
+
+You're a technical filter. Not everything a reviewer says is correct. Evaluate each comment against the actual code and project context, not memory, not assumptions, not the reviewer's authority.
+
+**Core principle:** Read before you reason. Verify before you implement. Project context is the ultimate authority.
+
+## Decision Flow
+
+```dot
+digraph review_flow {
+    rankdir=TB;
+    node [shape=box, style=rounded];
+
+    incoming [label="Review comments received", shape=doublecircle];
+    parse [label="Parse: claim + file + suggested fix"];
+    read_code [label="Read the actual code"];
+    check_docs [label="Check project docs\n(CLAUDE.md, AGENTS.md, etc.)"];
+    verify_framework [label="Verify framework claims\n(Context7 for version in use)"];
+    search_conventions [label="Search codebase for\nconventions & precedent"];
+
+    classify [label="Classify", shape=diamond];
+
+    high [label="VALID - HIGH IMPACT\nFix it", style=filled, fillcolor="#ffcccc"];
+    low [label="VALID - LOW IMPACT\nSurface only", style=filled, fillcolor="#ffffcc"];
+    fp [label="FALSE POSITIVE\nPush back with evidence", style=filled, fillcolor="#ccffcc"];
+    intentional [label="INTENTIONAL DESIGN\nCite doc/convention", style=filled, fillcolor="#ccffcc"];
+
+    present [label="Present verdicts table\n(before touching code)", shape=doublecircle];
+
+    incoming -> parse;
+    parse -> read_code;
+    read_code -> check_docs;
+    check_docs -> verify_framework;
+    verify_framework -> search_conventions;
+    search_conventions -> classify;
+    classify -> high [label="bug / security / breakage"];
+    classify -> low [label="cosmetic / style"];
+    classify -> fp [label="reviewer is wrong"];
+    classify -> intentional [label="project choice"];
+    high -> present;
+    low -> present;
+    fp -> present;
+    intentional -> present;
+}
+```
+
+## Step 1: Parse
+
+Extract from each comment: **claim**, **file/location**, **suggested fix**.
+
+## Step 2: Validate (Four Evidence Sources)
+
+Gather evidence from ALL four before forming an opinion:
+
+| Source | What to check |
+|---|---|
+| **Actual code** | Does the problem exist? Does surrounding context (guards, callers, error boundaries) change the analysis? |
+| **Project docs** | CLAUDE.md, AGENTS.md, CONTRIBUTING.md, UI pattern docs. "Gotchas" sections often preempt common review comments. |
+| **Framework docs** | Use Context7 (`resolve-library-id` → `query-docs`) for the exact version in use. Recommendations change across versions - a v2 best practice may be a v4 anti-pattern. |
+| **Codebase conventions** | Grep for the flagged pattern. If it appears consistently across the project, it's an established convention. Use `git log --follow` to check if the pattern was introduced intentionally. |
+
+**Evidence must come from these sources, never from memory or assumptions.**
+
+## Step 3: Classify
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| **VALID - HIGH IMPACT** | Bug, security gap, data integrity, a11y violation, broken behavior | Fix directly (high confidence) or present options (uncertain) |
+| **VALID - LOW IMPACT** | Cosmetic, stylistic, micro-optimization with no behavioral effect | Surface in table; do NOT implement unless asked |
+| **FALSE POSITIVE** | Reviewer is wrong: code is correct as written | Push back with specific evidence |
+| **INTENTIONAL DESIGN** | Deliberate project choice, documented or established by convention | Cite the doc section or codebase precedent |
+
+## Step 4: Present Verdicts
+
+Output a table **before touching any code**. Every verdict cites its evidence:
+
+```
+| # | Comment | Verdict | Reason |
+|---|---|---|---|
+| 1 | data?.items is unsafe | FALSE POSITIVE | Guard at L12 ensures data is never null in this code path |
+| 2 | Missing soft-delete filter | VALID - HIGH IMPACT | CLAUDE.md §Gotchas confirms BaseModel.is_active; query returns deleted records |
+| 3 | Unconventional import order | INTENTIONAL DESIGN | pyproject.toml disables isort; same ordering in 7 sibling files |
+| 4 | Variable name unclear | VALID - LOW IMPACT | Accurate observation, cosmetic only |
+```
+
+Then state: which you'll fix, which you're skipping, which need confirmation.
+
+## Step 5: Resolve
+
+Implementation order (aligns with receiving-code-review):
+1. **Blocking**: build breaks, security issues
+2. **Simple**: typos, missing filters, one-line corrections
+3. **Complex**: refactoring, logic changes, multi-file edits
+
+Test each fix individually. For uncertain cases (multiple valid approaches, regression risk): describe options and ask.
+
+## Discovering Project Conventions
+
+Don't memorize project-specific patterns; they go stale. Use this methodology each time:
+
+1. **Read project docs first**: "Gotchas" and "Conventions" sections answer common review comments before they're made
+2. **Search for precedent**: grep the flagged pattern across the codebase; consistency across many files signals intent
+3. **Check git blame**: `git log --follow -p <file>` reveals whether odd-looking code fixes a specific bug
+4. **Check tool config**: linter, typechecker, and formatter configs document intentional deviations from defaults
+5. **Verify framework claims with Context7**: "recommended way" is version-specific; check actual docs
+
+## Common Reviewer Errors
+
+These categories produce false positives across projects; verify carefully:
+
+- **Optional chaining complaints**: guards, fallbacks, or framework guarantees may make the chain safe
+- **"Missing" features**: the feature may be intentionally out of scope (check design docs)
+- **Import/style ordering**: many projects disable sorting to manage circular dependencies or grouping
+- **Architectural pattern "violations"**: the reviewer may not know the project's chosen patterns
+- **"Best practice" without version context**: framework recommendations evolve; verify against the version in use
+
+## Rationalization Guards
+
+When you catch yourself thinking these, STOP: you're rationalizing:
+
+| Rationalization | Reality |
+|---|---|
+| "The reviewer is probably right" | Probability is not verification. Check the code. |
+| "It's a small fix, I'll just do it" | Small fixes accumulate and can introduce regressions. Classify first. |
+| "I remember this pattern being wrong" | Memory is stale. Read the actual file. |
+| "The reviewer has more context" | You can read the entire codebase. They may not have. |
+| "It's safer to just make the change" | Unnecessary changes cause regressions. Push back on false positives. |
+| "I don't need to check docs for this" | Project conventions exist for a reason. Check them. |
+
+**Red flags: STOP and return to Step 2:**
+- You haven't read the actual file yet
+- You're about to agree without citing evidence
+- You can't name which doc section supports your verdict
+- You're implementing before presenting the verdicts table

--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,7 @@ POSTGRES_PORT=5432
 
 # Frontend
 VITE_API_URL=http://localhost:8000
+FRONTEND_PORT=5173
 
 # GitHub OAuth
 # Create a GitHub OAuth App at https://github.com/settings/developers

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This process is repetitive, fragmented, and error-prone.
     ├── backend/            # FastAPI backend
     ├── docker-compose.yml
     ├── docker-compose.override.yml
+    ├── docker-compose.prod.yml    # Production-specific overrides
     ├── .github/            # CI/CD workflows
     ├── README.md
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+# docker-compose.prod.yml
+# Production-specific overrides for DevTrackr.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# This file adds the production port mapping for the frontend service.
+# All other production defaults (target: prod, restart policies, healthchecks)
+# are already set in the base docker-compose.yml.
+
+services:
+  frontend:
+    ports:
+      # VPS must have a reverse proxy like Caddy or Nginx to forward traffic
+      # to the frontend container's port.
+      - "127.0.0.1:${FRONTEND_PORT?Frontend Port Not Set}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,10 +93,9 @@ services:
     restart: unless-stopped
     environment:
       - VITE_API_URL=${VITE_API_URL?Variable not set}
-    ports:
-      # VPS must have a reverse proxy like Caddy or Nginx to forward traffic
-      # to the frontend container's port
-      - "127.0.0.1:${FRONTEND_PORT?Frontend Port Not Set}:80"
+    # Port mapping is environment-specific:
+    #   Dev:  docker-compose.override.yml maps 5173:5173 (Vite dev server)
+    #   Prod: docker-compose.prod.yml maps 127.0.0.1:${FRONTEND_PORT}:80 (nginx)
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:18.1-trixie
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
       interval: 10s
       retries: 5
       start_period: 30s
@@ -43,7 +43,7 @@ services:
       - POSTGRES_PORT=${POSTGRES_PORT?Variable not set}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY?Variable not set}
 
-    command: ["./scripts/prestart.sh"]
+    command: [ "./scripts/prestart.sh" ]
 
   backend:
     container_name: devtrackr-backend
@@ -57,7 +57,8 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/ping'); exit(0)",
+          "import urllib.request;
+            urllib.request.urlopen('http://localhost:8000/api/ping'); exit(0)",
         ]
       interval: 10s
       retries: 5
@@ -93,7 +94,9 @@ services:
     environment:
       - VITE_API_URL=${VITE_API_URL?Variable not set}
     ports:
-      - "80:80" # Only expose the Production Web Server
+      # VPS must have a reverse proxy like Caddy or Nginx to forward traffic
+      # to the frontend container's port
+      - "127.0.0.1:${FRONTEND_PORT?Frontend Port Not Set}:80"
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request;
-            urllib.request.urlopen('http://localhost:8000/api/ping'); exit(0)",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/ping'); exit(0)",
         ]
       interval: 10s
       retries: 5

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -107,10 +107,31 @@ This script ensures that the frontend TypeScript types match the backend's OpenA
 ## 🚀 Running Locally
 
 ### With Docker (Recommended Service Setup)
+
 ```bash
 docker compose watch
 ```
-This will start the database, backend, and frontend, as well as ensure that the migrations are up to date.
+
+This starts the database, backend, and frontend with hot reload.
+The frontend is accessible at `http://localhost:5173`.
+
+### With Docker (Production / Staging)
+
+For a production or staging deployment on a VPS:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+This starts the services with production settings (no hot reload, nginx
+serving the built frontend). Ensure `FRONTEND_PORT` is set in your `.env`
+file (defaults to 5173). The VPS must have a reverse proxy (e.g., Caddy,
+Nginx) forwarding traffic from ports 80/443 to `localhost:${FRONTEND_PORT}`.
+
+> **Important:** Do not copy `docker-compose.override.yml` to the production
+> server. Compose auto-loads it and would reintroduce the port conflict.
+> The production server should only have `docker-compose.yml` and
+> `docker-compose.prod.yml`.
 
 ### Individual Services
 - **Backend**: `cd backend && uv run uvicorn app.main:app --reload`

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
   "vcs": {
-    "enabled": false,
+    "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": false
+    "useIgnoreFile": true
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**/*", "!src/client"]
+    "includes": ["**/*", "!dist", "!src/client", "!src/routeTree.gen.ts"]
   },
   "formatter": {
     "enabled": true,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { createRouter, RouterProvider } from "@tanstack/react-router";
 import "./App.css";
 import { routeTree } from "./routeTree.gen";
 

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,21 +1,31 @@
-import { createRootRoute, Link, Outlet } from '@tanstack/react-router'
-import * as React from 'react'
+import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
+import * as React from "react";
 
 export const Route = createRootRoute({
   component: RootComponent,
-})
+});
 
 function RootComponent() {
   return (
     <React.Fragment>
       <nav className="p-4 border-b flex gap-4">
-        <Link to="/" className="text-blue-500 hover:underline [&.active]:font-bold">Home</Link>
-        <Link to="/counter" className="text-blue-500 hover:underline [&.active]:font-bold">Counter</Link>
+        <Link
+          to="/"
+          className="text-blue-500 hover:underline [&.active]:font-bold"
+        >
+          Home
+        </Link>
+        <Link
+          to="/counter"
+          className="text-blue-500 hover:underline [&.active]:font-bold"
+        >
+          Counter
+        </Link>
       </nav>
       <div className="p-4">
         <hr className="my-4" />
         <Outlet />
       </div>
     </React.Fragment>
-  )
+  );
 }

--- a/frontend/src/routes/counter.tsx
+++ b/frontend/src/routes/counter.tsx
@@ -1,13 +1,13 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { useState } from 'react'
-import { Button } from '@/components/ui/button'
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
 
-export const Route = createFileRoute('/counter')({
+export const Route = createFileRoute("/counter")({
   component: CounterComponent,
-})
+});
 
 function CounterComponent() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(0);
 
   return (
     <div className="p-4 flex flex-col items-center gap-4">
@@ -18,5 +18,5 @@ function CounterComponent() {
         <Button onClick={() => setCount(count + 1)}>Increment</Button>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,9 +1,9 @@
-import { Button } from '@/components/ui/button'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
 
-export const Route = createFileRoute('/')({
+export const Route = createFileRoute("/")({
   component: HomeComponent,
-})
+});
 
 function HomeComponent() {
   return (
@@ -11,5 +11,5 @@ function HomeComponent() {
       <p>DevTrackr meow meow</p>
       <Button size="lg">Zingy</Button>
     </>
-  )
+  );
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,4 +19,12 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://backend:8000",
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
This pull request introduces configuration improvements for the frontend service, making it easier to customize the frontend port and encouraging best practices for production deployments. The most important changes are:

**Frontend configuration:**

* Added a `FRONTEND_PORT` variable to `.env.template` to allow easy customization of the frontend port.

**Production deployment guidance:**

* Updated the frontend service in `docker-compose.yml` to use the `FRONTEND_PORT` environment variable for port mapping and added comments explaining the need for a reverse proxy (like Caddy or Nginx) to forward traffic from port 80 to the frontend container.