### PR TITLE
feat(github): OAuth login and GitHub App installation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -30,6 +30,8 @@ FRONTEND_PORT=5173
 # Set the Authorization callback URL to: http://localhost:5173/api/auth/github/callback
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+GITHUB_PRIVATE_KEY_PATH=
+GITHUB_APP_SLUG=
 
 # Brevo Email settings
 SMTP_PORT=

--- a/.env.template
+++ b/.env.template
@@ -27,7 +27,7 @@ FRONTEND_PORT=5173
 
 # GitHub OAuth
 # Create a GitHub OAuth App at https://github.com/settings/developers
-# Set the callback URL to: http://localhost:8000/api/auth/github/callback
+# Set the Authorization callback URL to: http://localhost:5173/api/auth/github/callback
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,10 @@ jobs:
           # Frontend
           VITE_API_URL: http://localhost:8000
 
+          # GitHub OAuth (dummy values — not used at build time)
+          GITHUB_CLIENT_ID: dummy_client_id
+          GITHUB_CLIENT_SECRET: dummy_client_secret
+
           # Brevo Email settings
           # SMTP_PORT:
           # SMTP_HOST:

--- a/backend/app/alembic/versions/b7f2e6a91c34_add_github_installation_model.py
+++ b/backend/app/alembic/versions/b7f2e6a91c34_add_github_installation_model.py
@@ -1,0 +1,84 @@
+"""add github installation model
+
+Revision ID: b7f2e6a91c34
+Revises: c63043689179
+Create Date: 2026-06-25 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7f2e6a91c34"
+down_revision: str | Sequence[str] | None = "c63043689179"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "github_installation",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "installation_id",
+            sqlmodel.sql.sqltypes.AutoString(length=64),
+            nullable=False,
+        ),
+        sa.Column(
+            "account_login",
+            sqlmodel.sql.sqltypes.AutoString(length=255),
+            nullable=False,
+        ),
+        sa.Column(
+            "account_id", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False
+        ),
+        sa.Column(
+            "account_type", sqlmodel.sql.sqltypes.AutoString(length=32), nullable=False
+        ),
+        sa.Column("suspended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("user_id", sa.Uuid(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_github_installation_installation_id"),
+        "github_installation",
+        ["installation_id"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_github_installation_account_id"),
+        "github_installation",
+        ["account_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_github_installation_user_id"),
+        "github_installation",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_github_installation_user_id"), table_name="github_installation"
+    )
+    op.drop_index(
+        op.f("ix_github_installation_account_id"), table_name="github_installation"
+    )
+    op.drop_index(
+        op.f("ix_github_installation_installation_id"),
+        table_name="github_installation",
+    )
+    op.drop_table("github_installation")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from typing import Annotated
 
@@ -73,3 +74,57 @@ async def get_current_user(
 
 
 CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+async def get_current_user_optional(
+    session: Annotated[AsyncSession, Depends(get_db)],
+    access_token: Annotated[str | None, Cookie(alias=ACCESS_TOKEN_COOKIE_NAME)] = None,
+) -> User | None:
+    if not access_token:
+        return None
+
+    try:
+        payload = decode_token(access_token)
+        if payload.get("type") != "access":
+            return None
+        token_data = TokenPayload(**payload)
+        if not token_data.sub:
+            return None
+        user_id = uuid.UUID(token_data.sub)
+    except (jwt.PyJWTError, ValueError):
+        return None
+
+    user = await session.get(User, user_id)
+    if user is None or not user.is_active:
+        return None
+    return user
+
+
+OptionalCurrentUser = Annotated[User | None, Depends(get_current_user_optional)]
+
+
+async def get_github_jwt_token() -> str:
+    # Get PEM file path
+    pem = settings.GITHUB_PRIVATE_KEY_PATH
+
+    # Get the Client ID
+    client_id = settings.GITHUB_CLIENT_ID
+
+    # Open PEM
+    with open(pem, "rb") as pem_file:
+        signing_key = pem_file.read()
+
+    # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts
+    payload = {
+        "iat": int(time.time() - 60),
+        "exp": int(time.time()) + 600,
+        "iss": client_id,
+    }
+
+    # Create JWT
+    encoded_jwt = jwt.encode(payload, signing_key, algorithm="RS256")
+
+    return encoded_jwt
+
+
+GithubJWT = Annotated[str, Depends(get_github_jwt_token)]

--- a/backend/app/api/routes/github.py
+++ b/backend/app/api/routes/github.py
@@ -1,17 +1,15 @@
-"""GitHub OAuth routes using authlib.
+"""GitHub OAuth login and App installation routes.
 
-Flow:
-  1. GET  /auth/github/authorize  → redirects the browser to GitHub's consent page
-  2. GET  /auth/github/callback   → GitHub redirects here with a code; we exchange
-     it for an access token, fetch the user's profile, create or find the local
-     User + Integration records, set a JWT session cookie, and redirect to the
-     frontend.
-
-authlib's Starlette integration stores the OAuth "state" (CSRF nonce) in
-Starlette's SessionMiddleware cookie automatically.
+Two flows: OAuth login (``/authorize`` -> ``/callback``) and App installation
+(``/install`` -> ``/setup-callback``). The flows, the ``state`` CSRF model, and
+the ``GET /user/installations`` IDOR check are documented in
+``docs/github-oauth-and-app-install.md``.
 """
 
+import logging
+import secrets
 import uuid
+from datetime import datetime
 from typing import Any, cast
 
 from authlib.integrations.starlette_client import OAuth, OAuthError
@@ -20,25 +18,35 @@ from fastapi.responses import RedirectResponse
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.api.deps import CurrentUser
+from app.api.deps import CurrentUser, OptionalCurrentUser
 from app.core.config import settings
-from app.core.security import (
-    create_access_token,
-    set_auth_cookies,
-)
+from app.core.security import create_access_token, set_auth_cookies
 from app.crud.auth import create_session
-from app.crud.integration import create_integration, get_integration_by_provider
-from app.crud.user import create_user, get_user_by_email
+from app.crud.github_installation import (
+    get_installation_by_installation_id,
+    upsert_installation,
+)
+from app.crud.integration import (
+    create_integration,
+    get_integration_by_provider,
+    update_integration,
+)
+from app.crud.user import create_oauth_user, get_user_by_email
 from app.db.session import get_db
-from app.models.integration import Integration, IntegrationCreate
-from app.models.user import User, UserCreate
+from app.models.integration import (
+    Integration,
+    IntegrationCreate,
+    IntegrationUpdate,
+    OAuth2Token,
+)
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth/github", tags=["auth"])
 
 
 oauth = OAuth()
-
-
 oauth.register(
     name="github",
     client_id=settings.GITHUB_CLIENT_ID,
@@ -57,7 +65,7 @@ oauth.register(
 
 @router.get("/authorize")
 async def github_authorize(request: Request) -> RedirectResponse:
-    """Redirect the user to GitHub's OAuth consent page."""
+    """Redirect the user to GitHub's OAuth consent page for login."""
     redirect_uri = f"{settings.FRONTEND_HOST}{settings.API_STR}/auth/github/callback"
     return cast(
         RedirectResponse, await oauth.github.authorize_redirect(request, redirect_uri)
@@ -77,18 +85,15 @@ async def github_callback(
             detail=f"GitHub OAuth error: {exc.description}",
         ) from exc
 
-    # Fetch GitHub user profile
-    resp = await oauth.github.get("user", token=token)
-    github_user = resp.json()
-
+    # Resolve GitHub profile
+    github_user = (await oauth.github.get("user", token=token)).json()
     github_id = str(github_user["id"])
     github_email = github_user.get("email") or ""
     github_username = github_user.get("login", "")
 
-    # If GitHub profile doesn't have a public email, fetch from /user/emails
+    # Fall back to /user/emails when the profile has no public email.
     if not github_email:
-        emails_resp = await oauth.github.get("user/emails", token=token)
-        emails = emails_resp.json()
+        emails = (await oauth.github.get("user/emails", token=token)).json()
         primary = next(
             (e for e in emails if e.get("primary") and e.get("verified")), None
         )
@@ -101,44 +106,46 @@ async def github_callback(
             detail="Could not retrieve a verified email from GitHub",
         )
 
-    # check if we already have an integration with this GitHub account
-    result_integration = await session.exec(
+    # Find or create the GitHub integration
+    result = await session.exec(
         select(Integration).where(
             Integration.provider == "github",
             Integration.account_id == github_id,
         )
     )
-    existing_integration = result_integration.first()
+    existing_integration = result.first()
 
     if existing_integration:
-        # fetch the linked user
         user = await session.get(User, existing_integration.user_id)
+        # Refresh the stored token so it stays current.
+        await update_integration(
+            session=session,
+            db_obj=existing_integration,
+            integration_in=IntegrationUpdate(
+                access_token=token["access_token"],
+                refresh_token=token.get("refresh_token"),
+                account_email=github_email,
+            ),
+        )
     else:
         # check if a User with this email exists
         user = await get_user_by_email(session=session, email=github_email)
-
         if user is None:
-            # New user
-            user_create = UserCreate(
-                email=github_email, username=github_username, password=str(uuid.uuid4())
+            user = await create_oauth_user(
+                session=session, email=github_email, username=github_username
             )
-            user = await create_user(session=session, user_create=user_create)
-            # Nullify hashed_password just in case it should be null for OAuth-only
-            user.hashed_password = None
-            session.add(user)
-            await session.commit()
-            await session.refresh(user)
 
-        # Create the GitHub Integration record
-        integration_in = IntegrationCreate(
-            provider="github",
-            access_token=token["access_token"],
-            refresh_token=token.get("refresh_token"),
-            account_id=github_id,
-            account_email=github_email,
-        )
+        # Create the GitHub integration
         await create_integration(
-            session=session, integration_in=integration_in, user_id=user.id
+            session=session,
+            integration_in=IntegrationCreate(
+                provider="github",
+                access_token=token["access_token"],
+                refresh_token=token.get("refresh_token"),
+                account_id=github_id,
+                account_email=github_email,
+            ),
+            user_id=user.id,
         )
 
     if user is None or not user.is_active:
@@ -147,27 +154,213 @@ async def github_callback(
             detail="Account is inactive",
         )
 
-    access_token = create_access_token(user.id)
-    # Create a stateful DB session (Refresh Token)
+    access_token_jwt = create_access_token(user.id)
     refresh_token = await create_session(
         session=session,
         user_id=user.id,
         device_name=request.headers.get("user-agent"),
     )
 
-    response = RedirectResponse(url=settings.FRONTEND_HOST, status_code=302)
+    # Link any installation stashed by /setup-callback before login.
+    redirect_url = settings.FRONTEND_HOST
+    pending_installation_id = request.session.pop("pending_gh_installation", None)
+    if pending_installation_id:
+        outcome = await _link_installation(
+            session=session,
+            token=token,
+            installation_id=pending_installation_id,
+            user_id=user.id,
+        )
+        if outcome:
+            logger.warning(
+                "Pending installation link for user_id=%s did not complete: %s",
+                user.id,
+                outcome,
+            )
+        redirect_url = f"{settings.FRONTEND_HOST}?github_app={outcome or 'success'}"
 
-    set_auth_cookies(response, access_token, refresh_token)
-
+    response = RedirectResponse(url=redirect_url, status_code=302)
+    set_auth_cookies(response, access_token_jwt, refresh_token)
     return response
 
 
-# example for later, adapted from docs
+@router.get("/install")
+async def github_install(
+    request: Request, current_user: CurrentUser
+) -> RedirectResponse:
+    """Start a GitHub App installation (login required).
+
+    Sets a CSRF ``state`` in the session so ``/setup-callback`` can verify the
+    redirect came from us. See ``docs/github-oauth-and-app-install.md``.
+    """
+    state = secrets.token_urlsafe(32)
+    request.session["gh_install_state"] = state
+    install_url = (
+        f"https://github.com/apps/{settings.GITHUB_APP_SLUG}/installations/new"
+        f"?state={state}"
+    )
+    logger.info(
+        "User %s starting GitHub App install (state=%s...)", current_user.id, state[:8]
+    )
+    return RedirectResponse(install_url, status_code=302)
+
+
+@router.get("/setup-callback")
+async def github_setup_callback(
+    request: Request,
+    user: OptionalCurrentUser,
+    session: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """Handle the GitHub App Setup URL redirect after installation.
+
+    Links the installation when possible, otherwise stashes it and routes
+    through OAuth. See ``docs/github-oauth-and-app-install.md`` for the full
+    scenario table and security model.
+    """
+    installation_id = request.query_params.get("installation_id")
+    if not installation_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing installation_id in setup callback",
+        )
+
+    # Validate state to prevent CSRF attacks
+    callback_state = request.query_params.get("state")
+    expected_state = request.session.pop("gh_install_state", None)
+    if expected_state is not None:
+        if callback_state != expected_state:
+            logger.warning(
+                "Setup callback state mismatch (possible CSRF) for installation_id=%s",
+                installation_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid state for GitHub App installation",
+            )
+    else:
+        # No state set -> direct GitHub install or admin-approval flow.
+        logger.info(
+            "Setup callback without prior state for installation_id=%s", installation_id
+        )
+
+    # Stash the installation_id for OAuth redirect.
+    request.session["pending_gh_installation"] = installation_id
+
+    oauth_login_url = (
+        f"{settings.FRONTEND_HOST}{settings.API_STR}/auth/github/authorize"
+    )
+
+    if user is None:
+        logger.info(
+            "Not logged in for installation_id=%s; redirecting to OAuth",
+            installation_id,
+        )
+        return RedirectResponse(oauth_login_url, status_code=302)
+
+    # Logged in but no GitHub token yet -> get one via OAuth, then link.
+    integration = await get_integration_by_provider(
+        session=session, user_id=user.id, provider="github"
+    )
+    if not integration:
+        logger.info(
+            "User %s has no GitHub integration; redirecting to OAuth for "
+            "installation_id=%s",
+            user.id,
+            installation_id,
+        )
+        return RedirectResponse(oauth_login_url, status_code=302)
+
+    # Have a GitHub token -> link now and clear the pending stash.
+    outcome = await _link_installation(
+        session=session,
+        token=integration.to_token(),
+        installation_id=installation_id,
+        user_id=user.id,
+    )
+    request.session.pop("pending_gh_installation", None)
+
+    redirect_url = f"{settings.FRONTEND_HOST}?github_app={outcome or 'success'}"
+    return RedirectResponse(redirect_url, status_code=302)
+
+
+async def _link_installation(
+    *,
+    session: AsyncSession,
+    token: OAuth2Token,
+    installation_id: str,
+    user_id: uuid.UUID,
+) -> str | None:
+    """Verify an ``installation_id`` belongs to this user, then upsert it.
+
+    Authorization uses the user's OWN token, never the App JWT (which can read
+    any installation). Returns ``None`` on success or an outcome code
+    (``"unauthorized"``, ``"conflict"``, ``"error"``); never raises, since it
+    runs inside login/redirect flows that must complete regardless. See
+    ``docs/github-oauth-and-app-install.md``.
+    """
+    logger.info("Linking installation_id=%s for user_id=%s", installation_id, user_id)
+
+    try:
+        resp = await oauth.github.get(
+            "user/installations", token=token, params={"per_page": 100}
+        )
+        resp.raise_for_status()
+    except Exception:
+        logger.exception(
+            "GET /user/installations failed for installation_id=%s", installation_id
+        )
+        return "error"
+
+    installations = resp.json().get("installations", [])
+    matched = next(
+        (i for i in installations if str(i.get("id")) == str(installation_id)), None
+    )
+    if matched is None:
+        logger.warning(
+            "installation_id=%s not among user_id=%s installations -> unauthorized",
+            installation_id,
+            user_id,
+        )
+        return "unauthorized"
+
+    # Don't silently rebind an installation owned by another user.
+    existing = await get_installation_by_installation_id(
+        session=session, installation_id=str(installation_id)
+    )
+    if existing and existing.user_id and existing.user_id != user_id:
+        logger.warning(
+            "installation_id=%s already linked to user_id=%s -> conflict",
+            installation_id,
+            existing.user_id,
+        )
+        return "conflict"
+
+    account = matched.get("account") or {}
+    suspended_raw = matched.get("suspended_at")
+    await upsert_installation(
+        session=session,
+        installation_id=str(installation_id),
+        account_login=account.get("login", ""),
+        account_id=str(account.get("id", "")),
+        account_type=account.get("type", ""),
+        suspended_at=datetime.fromisoformat(suspended_raw) if suspended_raw else None,
+        user_id=user_id,
+    )
+    logger.info(
+        "Linked installation_id=%s (account=%s) to user_id=%s",
+        installation_id,
+        account.get("login", ""),
+        user_id,
+    )
+    return None
+
+
 @router.get("/repositories")
 async def get_github_repositories(
     current_user: CurrentUser,
     session: AsyncSession = Depends(get_db),
 ) -> list[dict[str, Any]]:
+    """List repositories accessible to the current user's GitHub integration."""
     integration = await get_integration_by_provider(
         session=session, user_id=current_user.id, provider="github"
     )
@@ -181,5 +374,4 @@ async def get_github_repositories(
     # Fetch GitHub repositories using the stored token
     resp = await oauth.github.get("user/repos", token=integration.to_token())
     resp.raise_for_status()
-
     return cast(list[dict[str, Any]], resp.json())

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,8 +26,10 @@ class Settings(BaseSettings):
     FRONTEND_HOST: str = "http://localhost:5173"
 
     # GitHub OAuth
-    GITHUB_CLIENT_ID: str = ""
-    GITHUB_CLIENT_SECRET: str = ""
+    GITHUB_CLIENT_ID: str
+    GITHUB_CLIENT_SECRET: str
+    GITHUB_PRIVATE_KEY_PATH: str
+    GITHUB_APP_SLUG: str
 
     # Integrations
     # None for now

--- a/backend/app/crud/github_installation.py
+++ b/backend/app/crud/github_installation.py
@@ -1,0 +1,67 @@
+import uuid
+from collections.abc import Sequence
+from datetime import datetime
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.github_installation import GitHubInstallation
+
+
+async def get_installation_by_installation_id(
+    *, session: AsyncSession, installation_id: str
+) -> GitHubInstallation | None:
+    statement = select(GitHubInstallation).where(
+        GitHubInstallation.installation_id == installation_id
+    )
+    result = await session.exec(statement)
+    return result.first()
+
+
+async def get_installations_by_user(
+    *, session: AsyncSession, user_id: uuid.UUID
+) -> Sequence[GitHubInstallation]:
+    statement = select(GitHubInstallation).where(GitHubInstallation.user_id == user_id)
+    result = await session.exec(statement)
+    return result.all()
+
+
+async def upsert_installation(
+    *,
+    session: AsyncSession,
+    installation_id: str,
+    account_login: str,
+    account_id: str,
+    account_type: str,
+    user_id: uuid.UUID,
+    suspended_at: datetime | None = None,
+) -> GitHubInstallation:
+    """Create the installation, or update it if it already exists."""
+    db_obj = await get_installation_by_installation_id(
+        session=session, installation_id=installation_id
+    )
+    if db_obj is None:
+        db_obj = GitHubInstallation(installation_id=installation_id)
+
+    db_obj.account_login = account_login
+    db_obj.account_id = account_id
+    db_obj.account_type = account_type
+    db_obj.suspended_at = suspended_at
+    db_obj.user_id = user_id
+
+    session.add(db_obj)
+    await session.commit()
+    await session.refresh(db_obj)
+    return db_obj
+
+
+async def delete_installation(
+    *, session: AsyncSession, installation_id: str
+) -> GitHubInstallation | None:
+    db_obj = await get_installation_by_installation_id(
+        session=session, installation_id=installation_id
+    )
+    if db_obj:
+        await session.delete(db_obj)
+        await session.commit()
+    return db_obj

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -20,6 +20,23 @@ async def create_user(*, session: AsyncSession, user_create: UserCreate) -> User
     return db_obj
 
 
+async def create_oauth_user(
+    *, session: AsyncSession, email: str, username: str
+) -> User:
+    """Create a passwordless user for OAuth-only sign-ups.
+
+    ``hashed_password`` stays NULL; the password-login paths reject NULL hashes,
+    so the account simply can't be accessed with a password (correct for an
+    OAuth-only account). The user can set a password later via the normal
+    update flow if you ever want to allow hybrid login.
+    """
+    db_obj = User(email=email, username=username, hashed_password=None)
+    session.add(db_obj)
+    await session.commit()
+    await session.refresh(db_obj)
+    return db_obj
+
+
 async def authenticate(
     *, session: AsyncSession, email: str, password: str
 ) -> User | None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import FastAPI
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -5,6 +7,10 @@ from app.api.main import api_router
 
 # Import settings to ensure it's loaded or fails fast if config is missing/invalid
 from app.core.config import settings  # noqa: F401
+
+# Surface app-level logs: uvicorn doesn't attach a root handler, so without this
+# our logger.info(...) calls would be swallowed (only WARNING+ would show).
+logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(title="DevTrackr API")
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from .auth import UserSessionToken
 from .base import BaseModel
 from .commit import Commit
+from .github_installation import GitHubInstallation
 from .integration import Integration
 from .logbook import Logbook
 from .project import Project
@@ -11,6 +12,7 @@ from .user import User
 __all__ = [
     "BaseModel",
     "Commit",
+    "GitHubInstallation",
     "Integration",
     "Logbook",
     "Project",

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlmodel import DateTime, Field, Relationship
+from sqlmodel import Column, DateTime, Field, Relationship
 
 from .base import BaseModel
 
@@ -17,8 +17,7 @@ class UserSessionToken(BaseModel, table=True):
     # Token data
     token_hash: str = Field(index=True, nullable=False)
     expires_at: datetime = Field(
-        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
-        nullable=False,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     is_revoked: bool = Field(default=False)
 

--- a/backend/app/models/commit.py
+++ b/backend/app/models/commit.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlmodel import DateTime, Field, SQLModel
+from sqlmodel import Column, DateTime, Field, SQLModel
 
 from .base import BaseModel
 
@@ -10,8 +10,7 @@ class CommitBase(SQLModel):
     sha: str
     message: str
     committed_at: datetime = Field(
-        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
-        nullable=False,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     url: str | None = None
 

--- a/backend/app/models/github_installation.py
+++ b/backend/app/models/github_installation.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlmodel import Column, DateTime, Field, Relationship
+
+from .base import BaseModel
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class GitHubInstallation(BaseModel, table=True):
+    __tablename__ = "github_installation"
+
+    # GitHub-assigned installation id
+    installation_id: str = Field(unique=True, index=True, max_length=64)
+
+    # The GitHub account the App is installed on.
+    account_login: str = Field(max_length=255)
+    account_id: str = Field(index=True, max_length=64)
+    account_type: str = Field(max_length=32)  # "User" | "Organization"
+
+    # Set when GitHub suspends the installation
+    suspended_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+
+    # The DevTrackr user who connected this installation
+    user_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="users.id",
+        ondelete="SET NULL",
+        nullable=True,
+        index=True,
+    )
+    user: Optional["User"] = Relationship(back_populates="github_installations")

--- a/backend/app/models/integration.py
+++ b/backend/app/models/integration.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, TypedDict
 
-from sqlmodel import DateTime, Field, Relationship, SQLModel
+from sqlmodel import Column, DateTime, Field, Relationship, SQLModel
 
 from .base import BaseModel
 from .base_types import EncryptedString
@@ -46,7 +46,7 @@ class Integration(IntegrationBase, BaseModel, table=True):
     )
     token_expiry: datetime | None = Field(
         default=None,
-        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
+        sa_column=Column(DateTime(timezone=True), nullable=True),
     )
 
     user_id: uuid.UUID = Field(

--- a/backend/app/models/time_entry.py
+++ b/backend/app/models/time_entry.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlmodel import DateTime, Field, SQLModel
+from sqlmodel import Column, DateTime, Field, SQLModel
 
 from .base import BaseModel
 
@@ -9,13 +9,11 @@ from .base import BaseModel
 class TimeEntryBase(SQLModel):
     description: str | None = Field(default=None)
     start_time: datetime = Field(
-        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
-        nullable=False,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     end_time: datetime | None = Field(
         default=None,
-        sa_type=DateTime(timezone=True),  # type: ignore[call-overload]
-        nullable=True,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
     )
     duration_seconds: int | None = None
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -7,6 +7,7 @@ from sqlmodel import Field, Relationship, SQLModel
 from .base import BaseModel
 
 if TYPE_CHECKING:
+    from .github_installation import GitHubInstallation
     from .integration import Integration
 
 
@@ -23,6 +24,9 @@ class User(UserBase, BaseModel, table=True):
 
     integrations: list["Integration"] = Relationship(
         back_populates="user", sa_relationship_kwargs={"lazy": "joined"}
+    )
+    github_installations: list["GitHubInstallation"] = Relationship(
+        back_populates="user", sa_relationship_kwargs={"lazy": "selectin"}
     )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,25 @@
 name: "DevTrackr Services"
 
+# x- extension to ensure required variables are present
+# https://docs.docker.com/reference/compose-file/extension/
+x-required-env:
+  postgres:
+    POSTGRES_USER: ${POSTGRES_USER?}
+    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD?}
+    POSTGRES_DB: ${POSTGRES_DB?}
+  backend:
+    DOMAIN: ${DOMAIN?}
+    PROJECT_NAME: ${PROJECT_NAME?}
+    FRONTEND_HOST: ${FRONTEND_HOST?}
+    ENVIRONMENT: ${ENVIRONMENT?}
+    SECRET_KEY: ${SECRET_KEY?}
+    BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS?}
+    ENCRYPTION_KEY: ${ENCRYPTION_KEY?}
+    GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID?}
+    GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET?}
+  frontend:
+    VITE_API_URL: ${VITE_API_URL?}
+
 services:
   database:
     container_name: devtrackr-database
@@ -13,11 +33,9 @@ services:
       timeout: 10s
     volumes:
       - devtrackr-postgres-data:/var/lib/postgresql/data
+    env_file: .env
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
-      - POSTGRES_USER=${POSTGRES_USER?Variable not set}
-      - POSTGRES_DB=${POSTGRES_DB?Variable not set}
 
   prestart:
     container_name: devtrackr-prestart
@@ -29,19 +47,9 @@ services:
     depends_on:
       database:
         condition: service_healthy
+    env_file: .env
     environment:
-      - DOMAIN=${DOMAIN?Variable not set}
-      - PROJECT_NAME=${PROJECT_NAME?Variable not set}
-      - FRONTEND_HOST=${FRONTEND_HOST?Variable not set}
-      - ENVIRONMENT=${ENVIRONMENT?Variable not set}
-      - SECRET_KEY=${SECRET_KEY?Variable not set}
-      - BACKEND_CORS_ORIGINS=${BACKEND_CORS_ORIGINS?Variable not set}
-      - POSTGRES_USER=${POSTGRES_USER?Variable not set}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
-      - POSTGRES_DB=${POSTGRES_DB?Variable not set}
       - POSTGRES_HOST=database
-      - POSTGRES_PORT=${POSTGRES_PORT?Variable not set}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY?Variable not set}
 
     command: [ "./scripts/prestart.sh" ]
 
@@ -69,19 +77,9 @@ services:
         condition: service_healthy
       prestart:
         condition: service_completed_successfully
+    env_file: .env
     environment:
-      - DOMAIN=${DOMAIN?Variable not set}
-      - PROJECT_NAME=${PROJECT_NAME?Variable not set}
-      - FRONTEND_HOST=${FRONTEND_HOST?Variable not set}
-      - ENVIRONMENT=${ENVIRONMENT?Variable not set}
-      - SECRET_KEY=${SECRET_KEY?Variable not set}
-      - BACKEND_CORS_ORIGINS=${BACKEND_CORS_ORIGINS?Variable not set}
-      - POSTGRES_USER=${POSTGRES_USER?Variable not set}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
-      - POSTGRES_DB=${POSTGRES_DB?Variable not set}
       - POSTGRES_HOST=database
-      - POSTGRES_PORT=${POSTGRES_PORT?Variable not set}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY?Variable not set}
 
   frontend:
     container_name: devtrackr-frontend
@@ -90,8 +88,7 @@ services:
       dockerfile: Dockerfile
       target: prod
     restart: unless-stopped
-    environment:
-      - VITE_API_URL=${VITE_API_URL?Variable not set}
+    env_file: .env
     # Port mapping is environment-specific:
     #   Dev:  docker-compose.override.yml maps 5173:5173 (Vite dev server)
     #   Prod: docker-compose.prod.yml maps 127.0.0.1:${FRONTEND_PORT}:80 (nginx)

--- a/docs/github-oauth-and-app-install.md
+++ b/docs/github-oauth-and-app-install.md
@@ -1,0 +1,75 @@
+# GitHub OAuth & App Installation
+
+How DevTrackr authenticates users with GitHub and links GitHub App
+installations. The implementation lives in `backend/app/api/routes/github.py`.
+
+## Overview
+
+There are two separate flows, and keeping them separate is deliberate:
+
+1. **OAuth login** (`/auth/github/authorize` → `/auth/github/callback`)
+   Standard GitHub OAuth (authlib manages `state` + PKCE). Lets a user sign up
+   or sign in with their GitHub account. No app installation happens here.
+2. **App installation** (`/auth/github/install` → `/auth/github/setup-callback`)
+   Links a GitHub App installation to a DevTrackr user.
+
+The GitHub App's **Setup URL** must point at `/auth/github/setup-callback`.
+
+> Do **not** enable "Request user authorization (OAuth) during installation" in
+> the GitHub App settings. It merges the two flows into a single callback that
+> arrives without a `state` parameter, weakening CSRF protection.
+
+## Security model
+
+### `state` — CSRF defense-in-depth
+
+`/install` generates a random `state` (`secrets.token_urlsafe`), stores it in
+the user's signed session cookie, and passes it to GitHub. GitHub echoes it back
+to `/setup-callback`, where we compare the (untrusted) query param against the
+(trusted, HMAC-signed) session value. An attacker can neither read nor forge the
+victim's session state, so a forged callback fails the check.
+
+`state` is **present** only for website-initiated installs. GitHub **drops** it
+for direct installs from github.com and for org-admin approvals on behalf of a
+non-admin requester (see GitHub community discussions #53626, #64239). A missing
+`state` is therefore expected and handled gracefully — it is not treated as an
+attack.
+
+### `GET /user/installations` — IDOR protection (non-negotiable)
+
+Even when `state` is legitimately missing, we never trust the
+`installation_id` query param on its own. Before linking, we call GitHub's
+`GET /user/installations` **with the user's own token** and confirm the
+`installation_id` appears in that list. A spoofed `installation_id` will never
+show up under a different user, so it can't be bound to the attacker's account.
+
+We authorize against the user's token, **never** the App JWT — the App JWT can
+read *any* installation, which would defeat the check.
+
+## `/setup-callback` scenarios
+
+GitHub redirects here after an install with
+`?installation_id=…&setup_action=install [&state=…]`.
+
+| `state`            | User state                       | Action                                              |
+| ------------------ | -------------------------------- | --------------------------------------------------- |
+| present, valid     | —                                | Link after verifying via `GET /user/installations`  |
+| present, mismatch  | —                                | Reject as CSRF (`401`)                              |
+| absent             | not logged in                    | Stash installation, redirect to OAuth; link on `/callback` |
+| absent             | logged in, no GitHub token       | Stash installation, redirect to OAuth; link on `/callback` |
+| absent             | logged in with a GitHub token    | Link immediately                                    |
+
+The pending `installation_id` is stored in the session so it survives the OAuth
+round-trip; `/callback` links it once the user has a token.
+
+## Link outcomes
+
+`_link_installation` returns `None` on success, or a short code surfaced to the
+frontend via `?github_app=…`:
+
+| Code             | Meaning                                  |
+| ---------------- | ---------------------------------------- |
+| `success`        | Installation linked                      |
+| `unauthorized`   | `installation_id` is not one of the user's installations |
+| `conflict`       | Installation is already linked to a different user |
+| `error`          | GitHub API call failed                   |

--- a/docs/references.md
+++ b/docs/references.md
@@ -8,6 +8,7 @@
 - https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps
 - https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/using-webhooks-with-github-apps#choosing-a-webhook-url-for-development-and-testing
 - https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+- https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts
 
 ### ADR (Architecture Decision Record):
 - https://github.com/joelparkerhenderson/architecture-decision-record?tab=readme-ov-file

--- a/docs/references.md
+++ b/docs/references.md
@@ -4,6 +4,11 @@
 - https://docs.github.com/en/actions/get-started/continuous-integration
 - https://docs.github.com/en/actions/reference/workflows-and-actions/contexts
 
+### GitHub Apps
+- https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps
+- https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/using-webhooks-with-github-apps#choosing-a-webhook-url-for-development-and-testing
+- https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+
 ### ADR (Architecture Decision Record):
 - https://github.com/joelparkerhenderson/architecture-decision-record?tab=readme-ov-file
 - https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-michael-nygard
@@ -34,3 +39,4 @@
 - https://docs.github.com/en/rest/quickstart?apiVersion=2022-11-28
 
 ### Docker
+- https://docs.docker.com/reference/compose-file/extension/

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,15 +1,150 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/")({
   component: HomeComponent,
 });
 
+const inputClass =
+  "h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50";
+
+// Bare-bones auth controls for manual testing. Design is owned elsewhere.
 function HomeComponent() {
+  const [status, setStatus] = useState("checking…");
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const isAuthed = status.startsWith("logged in");
+
+  // Probe the current session so we can see whether login/logout worked.
+  useEffect(() => {
+    fetch("/api/auth/me", { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((user) => setStatus(`logged in as ${user.email}`))
+      .catch(() => setStatus("not logged in"));
+  }, []);
+
+  // GitHub OAuth login. Same-tab navigation so the session cookie round-trips.
+  const githubLogin = () => {
+    window.location.href = "/api/auth/github/authorize";
+  };
+
+  // Email/password login. Sets the auth cookies on success.
+  const login = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch("/api/auth/login", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      window.location.reload();
+    } else {
+      setStatus(`login failed (${res.status})`);
+    }
+  };
+
+  // Create an email/password user (needs username too). Logs in on success.
+  const register = async () => {
+    const res = await fetch("/api/auth/register", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, username, password }),
+    });
+    if (res.ok) {
+      window.location.reload();
+    } else {
+      setStatus(`register failed (${res.status})`);
+    }
+  };
+
+  const logout = async () => {
+    await fetch("/api/auth/logout", { method: "POST", credentials: "include" });
+    window.location.reload();
+  };
+
   return (
-    <>
-      <p>DevTrackr meow meow</p>
-      <Button size="lg">Zingy</Button>
-    </>
+    <div className="mx-auto max-w-sm">
+      <p className="mb-3 rounded-md border border-dashed px-3 py-2 text-center text-xs text-muted-foreground">
+        ⚠️ Temporary Auth and GitHub flow test page.
+      </p>
+      <div className="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <h1 className="text-lg font-semibold tracking-tight">DevTrackr</h1>
+        <div className="mt-1 mb-5 flex items-center gap-2 text-sm text-muted-foreground">
+          <span
+            className={`size-1.5 shrink-0 rounded-full ${
+              isAuthed ? "bg-emerald-500" : "bg-muted-foreground/40"
+            }`}
+          />
+          <span className="truncate">{status}</span>
+        </div>
+
+        <form onSubmit={login} className="flex flex-col gap-2.5">
+          <input
+            type="email"
+            placeholder="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={inputClass}
+          />
+          <input
+            type="text"
+            placeholder="username (register only)"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className={inputClass}
+          />
+          <input
+            type="password"
+            placeholder="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={inputClass}
+          />
+          <div className="mt-1 flex gap-2">
+            <Button type="submit" className="flex-1">
+              Login
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              className="flex-1"
+              onClick={register}
+            >
+              Register
+            </Button>
+          </div>
+        </form>
+
+        <div className="my-4 flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="h-px flex-1 bg-border" />
+          or
+          <span className="h-px flex-1 bg-border" />
+        </div>
+
+        <Button onClick={githubLogin} variant="outline" className="w-full">
+          Login with GitHub
+        </Button>
+
+        <div className="mt-4 flex items-center justify-between text-sm">
+          {/* Go through the backend so it sets the CSRF `state` before
+              redirecting to GitHub's install page. Must be same-tab (no
+              target=_blank) so the session cookie round-trips. */}
+          <a
+            href="/api/auth/github/install"
+            target="_self"
+            className="text-blue-500 hover:underline"
+          >
+            Install GitHub App
+          </a>
+          <Button onClick={logout} variant="ghost" size="sm">
+            Logout
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds GitHub OAuth login and GitHub App installation linking, along with the
supporting model, infra, and config changes this branch accumulated.

## GitHub auth (main feature)

- **OAuth login** (`/auth/github/authorize` → `/auth/github/callback`): sign up /
  sign in with a GitHub account; creates the user + integration and issues
  session cookies.
- **App installation** (`/auth/github/install` → `/auth/github/setup-callback`):
  links a GitHub App installation to a DevTrackr user.
- **Security model:**
  - Session-based `state` CSRF defense-in-depth — set on website-initiated
    installs; GitHub drops it for direct installs and org-admin approvals, which
    is handled gracefully.
  - `GET /user/installations` IDOR check — the `installation_id` is verified
    against the user's own token before binding, so a spoofed one can't be linked.
- New `GitHubInstallation` model + CRUD + Alembic migration, a
  `get_current_user_optional` dependency, a `create_oauth_user` CRUD helper, and
  related `config` / `.env.template` settings.
- Flows and security model documented in `docs/github-oauth-and-app-install.md`.

## Supporting changes

- **Compose:** load service env via `env_file: .env` with an `x-required-env`
  extension to document and enforce required variables; fix the GitHub OAuth
  callback URL guidance in `.env.template`; add GitHub Apps / Docker references.
- **Models:** replace `sa_type` with explicit `sa_column` definitions for
  SQLModel compatibility.
- **CI:** add dummy GitHub client id/secret so the Docker build step runs.

## Frontend

`frontend/src/routes/index.tsx` is a **temporary** auth / GitHub-flow test page
(login, register, GitHub login, install, logout), clearly marked as not the real
UI. The production UI is owned separately.

## Testing

Manual: login / register / GitHub OAuth / app install / logout exercised via the
temporary test page.
